### PR TITLE
Change link placeholder

### DIFF
--- a/src/components/LinkCreator/LinkCreator.vue
+++ b/src/components/LinkCreator/LinkCreator.vue
@@ -9,7 +9,7 @@
       <div class="grid md:grid-cols-2 gap-5">
         <Field
           title="Full URL"
-          placeholder="https://google.com/page"
+          placeholder="https://example.com/page"
           inputType="url"
           :errorMessage="errorMsgFullUrl"
           v-model="fullURL"


### PR DESCRIPTION
Replace `google` with `example` in placeholder.